### PR TITLE
Add vendor prefixing

### DIFF
--- a/src/cato.js
+++ b/src/cato.js
@@ -3,7 +3,7 @@
 
 import setInsetDirection from './util/setInsetDirection.js'
 import { addClass } from './util/domClasses.js'
-import { setStyles } from './util/setStyles.js'
+import { setStyles, setVendor } from './util/setStyles.js'
 import './cato.css'
 
 export default class Cato {
@@ -59,10 +59,11 @@ export default class Cato {
       this.options.direction === 'horizontal'
         ? (imgBase.width * this.options.initial) / 100
         : (imgBase.height * this.options.initial) / 100
-    imgBase.style.clipPath = setInsetDirection(
-      this.options.direction,
-      initialClip,
-    )
+    
+		setVendor(imgBase, "ClipPath", setInsetDirection(
+			this.options.direction,
+			initialClip,
+		))
 
     // flip input range and adjust to the side if vertical
     if (this.options.direction === 'vertical') {
@@ -113,10 +114,10 @@ export default class Cato {
         ? (width * this.range.value) / 100
         : (height * this.range.value) / 100
 
-    this.imgBase.style.clipPath = setInsetDirection(
-      this.options.direction,
-      slidedWith,
-    )
+		setVendor(this.imgBase, "ClipPath", setInsetDirection(
+			this.options.direction,
+			slidedWith,
+		))
     this.resizeIndicator()
     return false
   }

--- a/src/util/setStyles.js
+++ b/src/util/setStyles.js
@@ -2,4 +2,12 @@ const setStyles = (el, styles) => {
   Object.assign(el.style, styles)
 }
 
-export { setStyles }
+const setVendor = (el, property, value) => {
+	el.style['Webkit' + property] = value;
+	el.style['Moz' + property] = value;
+	el.style['ms' + property] = value;
+	el.style['o' + property] = value;
+	el.style.property = value;
+}
+
+export { setStyles, setVendor }


### PR DESCRIPTION
fixes #19 

This is my attempt to solve Safari incompatibility by solving vendor prefixing of clip-path.
More detailed description in issue #19 

My setVendor function is pretty basic.
A few other solutions are mentioned in: https://stackoverflow.com/questions/8889014/setting-vendor-prefixed-css-using-javascript